### PR TITLE
Added test in MergePipeAssemblyTest.java that throws FileAlreadyExistsException.

### DIFF
--- a/cascading-platform/src/test/java/cascading/MergePipeAssemblyTest.java
+++ b/cascading-platform/src/test/java/cascading/MergePipeAssemblyTest.java
@@ -77,4 +77,53 @@ public class MergePipeAssemblyTest extends PlatformTestCase {
 		assertTrue(results.contains(new Tuple("CCC","ASD","DFG")));
 		assertTrue(results.contains(new Tuple("NNN","IUY","OWER")));
 	}
+	
+	@Test
+	public void testThrowsFileAlreadyExitsException() throws IOException{
+		
+		System.setProperty( "platform.includes", "hadoop2-mr1");
+	
+		getPlatform().copyFromLocal(testDelimitedFile1);
+		getPlatform().copyFromLocal(testDelimitedFile2);
+		
+		Tap source1 = getPlatform().getDelimitedFile(
+  				new Fields("f1", "f2", "f3"), false, "|", null,
+  				new Class[] { String.class, String.class, String.class }, testDelimitedFile1,
+  				SinkMode.KEEP);
+		
+		Tap source2 = getPlatform().getDelimitedFile(
+  				new Fields("f1", "f2", "f3"), false, "|", null,
+  				new Class[] { String.class, String.class, String.class }, testDelimitedFile2,
+  				SinkMode.KEEP);
+		
+		Tap sink = getPlatform().getDelimitedFile(
+  				new Fields("f1", "f2", "f3"), false, "|", null,
+  				new Class[] { String.class, String.class, String.class },
+  				getOutputPath("exceptiontest_output"), SinkMode.REPLACE);
+		
+		Pipe inputPipe1 = new Pipe("Input Pipe 1");
+		Pipe inputPipe2 = new Pipe("Input Pipe 2");
+		
+		Fields f1 = new Fields("f1");
+		
+		Pipe groupByPipe1 = new GroupBy("GroupBy Pipe 1", inputPipe1, f1);
+				
+		First firstTuple = new First();
+		
+		Pipe everyPipe1 = new Every(groupByPipe1, firstTuple, Fields.RESULTS);
+				
+		Pipe mergePipe = new Merge("Merge Pipe", everyPipe1, inputPipe2);
+		
+		FlowDef flowDef = FlowDef.flowDef().addSource(inputPipe1, source1)
+				.addSource(inputPipe2, source2).addTailSink(mergePipe, sink);
+
+		Flow flow = getPlatform().getFlowConnector().connect(flowDef);
+		
+		flow.complete();
+		
+		List<Tuple> results = asList( flow, sink);
+		
+		assertTrue(results.contains(new Tuple("CCC","ASD","DFG")));
+		assertTrue(results.contains(new Tuple("NNN","IUY","OWER")));
+	}
 }


### PR DESCRIPTION
Hi Chris,

I have added a test `testThrowsFileAlreadyExistsException()` in `cascading.MergePipeAssemblyTest.java`. The test case is for [FileAlreadyExistsException](https://groups.google.com/forum/#!topic/cascading-user/ZIY13qa4zHo) issue. The class also contains test `testMergePipeAssembly()` which is for [PlannerException: union of steps have 3 fewer elements than parent assembly](https://groups.google.com/forum/#!topic/cascading-user/3_PiTtjtoTU) issue with [this](https://github.com/cwensel/cascading/pull/44) pull request.

Thanks,
Pushpak D Gohey
